### PR TITLE
Close leaked connections when the cypher query returns an error

### DIFF
--- a/observation/store.go
+++ b/observation/store.go
@@ -53,6 +53,8 @@ func (store *Store) GetCSVRows(filter *Filter, limit *int) (CSVRowReader, error)
 
 	rows, err := conn.QueryNeo(unionQuery, nil)
 	if err != nil {
+		// Before returning the error "close" the open connection to release it back into the pool.
+		conn.Close()
 		return nil, err
 	}
 	// The connection can only be closed once the results have been read, so the row reader is responsible for


### PR DESCRIPTION
### What

Address leaked connections when filtering a CSV

### How to review

Review the code, checkout and test the preview endpoint on https://github.com/ONSdigital/dp-filter-api/tree/fix/recover-connections

### Who can review

@CarlHembrough 
