### PR TITLE
fix defect where query with empty dimension options fails to return a…

### DIFF
--- a/observation/store_test.go
+++ b/observation/store_test.go
@@ -208,7 +208,7 @@ func TestStore_GetCSVRowsDimensionEmpty(t *testing.T) {
 
 		store := observation.NewStore(mockedPool)
 
-		Convey("When GetCSVRows is called a with a filter with an empty dimension options and no limit", func() {
+		Convey("When GetCSVRows is called with a filter with an empty dimension options and no limit", func() {
 
 			expectedQuery := "MATCH (i:`_888_Instance`) RETURN i.header as row " +
 				"UNION ALL " +


### PR DESCRIPTION
**What** fix for defect where passing a filter with dimension with no options causes query to not match anything - which breaks the xlsx exporter further down the pipeline.

If the dimension options is an empty list the generated query contains `your_dimension.value IN []` which will always fail to match anything.

Change checks if the dimension option is empty and if so excludes that dimension from the generated query.

**Who** anyone


