### PR TITLE
Update observation reader to count observations read so far

### DIFF
--- a/observation/reader.go
+++ b/observation/reader.go
@@ -11,6 +11,7 @@ type Reader struct {
 	buffer         []byte // buffer a portion of the current line
 	eof            bool   // are we at the end of the csv rows?
 	totalBytesRead int64  // how many bytes in total have been read?
+	obsCount       int32
 }
 
 // NewReader returns a new io.Reader for the given csvRowReader.
@@ -33,6 +34,7 @@ func (reader *Reader) Read(p []byte) (n int, err error) {
 		}
 
 		reader.buffer = []byte(csvRow)
+		reader.obsCount++
 	}
 
 	// copy into the given byte array.
@@ -61,4 +63,9 @@ func (reader *Reader) Close() (err error) {
 // TotalBytesRead returns the total number of bytes read by this reader.
 func (reader *Reader) TotalBytesRead() int64 {
 	return reader.totalBytesRead
+}
+
+// ObservationsCount returns the total number of bytes read by this reader.
+func (reader *Reader) ObservationsCount() int32 {
+	return reader.obsCount
 }

--- a/observation/reader_test.go
+++ b/observation/reader_test.go
@@ -1,12 +1,13 @@
 package observation_test
 
 import (
-	"github.com/ONSdigital/dp-filter/observation"
-	"github.com/ONSdigital/dp-filter/observation/observationtest"
-	. "github.com/smartystreets/goconvey/convey"
 	"io"
 	"reflect"
 	"testing"
+
+	"github.com/ONSdigital/dp-filter/observation"
+	"github.com/ONSdigital/dp-filter/observation/observationtest"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestReader_Read(t *testing.T) {
@@ -134,6 +135,7 @@ func TestReader_Read_MultipleLines(t *testing.T) {
 				So(reflect.DeepEqual(expected, read3[:expectedLen]), ShouldBeTrue)
 
 				So(reader.TotalBytesRead(), ShouldEqual, expectedLen*3) // should have read the row content 3 times
+				So(reader.ObservationsCount(), ShouldEqual, 3)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Added ability to track the number of observations that have been read, which can be used by the exporters to understand the 'size' of the dataset being read from the graph.

### How to review

Check works, passes tests, seems sensible, and solves problem.

### Who can review

anyone