### PR TITLE
Remove WITH and IN from neo query for efficiency

### DIFF
--- a/observation/store.go
+++ b/observation/store.go
@@ -1,9 +1,9 @@
 package observation
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/ONSdigital/go-ns/log"
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
@@ -95,18 +95,11 @@ func createObservationQuery(filter *Filter) string {
 }
 
 func createOptionList(name string, opts []string) string {
-	var buffer bytes.Buffer
+	var q []string
 
-	buffer.WriteString("(")
-	l := len(opts) - 1
-	for i, o := range opts {
-		buffer.WriteString(fmt.Sprintf("%s.value='%s'", name, o))
-
-		if i < l {
-			buffer.WriteString(" OR ")
-		}
+	for _, o := range opts {
+		q = append(q, fmt.Sprintf("%s.value='%s'", name, o))
 	}
-	buffer.WriteString(")")
 
-	return buffer.String()
+	return fmt.Sprintf("(%s)", strings.Join(q, " OR "))
 }

--- a/observation/store_test.go
+++ b/observation/store_test.go
@@ -2,11 +2,12 @@ package observation_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/ONSdigital/dp-filter/observation"
 	"github.com/ONSdigital/dp-filter/observation/observationtest"
 	bolt "github.com/johnnadratowski/golang-neo4j-bolt-driver"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func TestStore_GetCSVRows(t *testing.T) {
@@ -23,11 +24,9 @@ func TestStore_GetCSVRows(t *testing.T) {
 
 		expectedQuery := "MATCH (i:`_888_Instance`) RETURN i.header as row " +
 			"UNION ALL " +
-			"MATCH (age:`_888_age`), (sex:`_888_sex`) " +
-			"WHERE age.value IN ['29', '30'] " +
-			"AND sex.value IN ['male', 'female'] " +
-			"WITH age, sex " +
-			"MATCH (o:`_888_observation`)-[:isValueOf]->(age), (o:`_888_observation`)-[:isValueOf]->(sex) " +
+			"MATCH (o)-[:isValueOf]->(age:`_888_age`), (o)-[:isValueOf]->(sex:`_888_sex`) " +
+			"WHERE (age.value='29' OR age.value='30') " +
+			"AND (sex.value='male' OR sex.value='female') " +
 			"RETURN o.value AS row"
 
 		expectedCSVRow := "the,csv,row"
@@ -213,10 +212,8 @@ func TestStore_GetCSVRowsDimensionEmpty(t *testing.T) {
 
 			expectedQuery := "MATCH (i:`_888_Instance`) RETURN i.header as row " +
 				"UNION ALL " +
-				"MATCH (age:`_888_age`) " +
-				"WHERE age.value IN ['29', '30'] " +
-				"WITH age " +
-				"MATCH (o:`_888_observation`)-[:isValueOf]->(age) " +
+				"MATCH (o)-[:isValueOf]->(age:`_888_age`) " +
+				"WHERE (age.value='29' OR age.value='30') " +
 				"RETURN o.value AS row"
 
 			rowReader, err := store.GetCSVRows(filter, nil)


### PR DESCRIPTION
### What

Following performance issues with large datasets, and several hours of performance testing different query options in neo, turns out WITH and IN are both less efficient. Also, the previous query was matching twice, which was causing an uneccesary read of the entire dataset. 

### How to review

Vendor this change in to an app which queries neo and test that the results come back more quickly

### Who can review

anyone