### PR TITLE
Add quotes around variable names for cypher queries for safety

### DIFF
--- a/observation/store.go
+++ b/observation/store.go
@@ -85,7 +85,7 @@ func createObservationQuery(filter *Filter) string {
 				where += " AND "
 			}
 
-			matchDimensions += fmt.Sprintf("(o)-[:isValueOf]->(%s:`_%s_%s`)", dimension.Name, filter.InstanceID, dimension.Name)
+			matchDimensions += fmt.Sprintf("(o)-[:isValueOf]->(`%s`:`_%s_%s`)", dimension.Name, filter.InstanceID, dimension.Name)
 			where += createOptionList(dimension.Name, dimension.Options)
 			count++
 		}
@@ -98,7 +98,7 @@ func createOptionList(name string, opts []string) string {
 	var q []string
 
 	for _, o := range opts {
-		q = append(q, fmt.Sprintf("%s.value='%s'", name, o))
+		q = append(q, fmt.Sprintf("`%s`.value='%s'", name, o))
 	}
 
 	return fmt.Sprintf("(%s)", strings.Join(q, " OR "))


### PR DESCRIPTION
### What

Add backticks around variable names in cypher queries - the values that are assigned to these are strings, but sometimes begin with number or may contain hyphens. In these cases, without the backticks, it is not valid cypher. The backticks provide more safety around the strings we use, and allow us more flexibility in dimension names

### How to review

check dimension names like '1961geography' and 'age-group' can be filtered

### Who can review

anyone